### PR TITLE
Don't attempt to backup files in .git

### DIFF
--- a/plugin/backup_git.vim
+++ b/plugin/backup_git.vim
@@ -81,6 +81,11 @@ function! s:BackupCurrentFile()
 
     " 1. Backup the file
     let l:file = expand('%:p')  " e.g. '/tmp/foo.txt'
+
+    if l:file =~ '\.git'
+        return
+    endif
+
     let l:backup_file = g:custom_backup_dir . l:file  " e.g. '~/.vim_custom_backups/tmp/foo.txt'
     let l:relative_backup_file = vim_git_backup#filer#strip_mount(l:file)  " e.g. 'tmp/foo.txt'
 


### PR DESCRIPTION
If you have `EDITOR=vim` and execute `git commit`, you'll be prompted with a vim editor to add your commit message. Upon writing your changes, a file is saved in .git, in a file named COMMIT_EDITMSG. While the file gets copied to the backup directory, the file is also ignored due to it existing in a directory named `.git`.

I wasn't able to identify what is ignoring that directory, but I suspect it might be a safeguard in git itself, not to allow directories named `.git`.